### PR TITLE
Lint upper camel case

### DIFF
--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -163,7 +163,7 @@ struct s;
 This will produce:
 
 ```text
-warning: type `s` should have a camel case name such as `S`
+warning: type `s` should have an upper camel case name such as `S`
  --> src/main.rs:1:1
   |
 1 | struct s;

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -89,9 +89,9 @@ impl NonCamelCaseTypes {
         if !is_camel_case(name) {
             let c = to_camel_case(&name.as_str());
             let m = if c.is_empty() {
-                format!("{} `{}` should have a camel case name such as `CamelCase`", sort, name)
+                format!("{} `{}` should have an upper camel case name such as `CamelCase`", sort, name)
             } else {
-                format!("{} `{}` should have a camel case name such as `{}`", sort, name, c)
+                format!("{} `{}` should have an upper camel case name such as `{}`", sort, name, c)
             };
             cx.span_lint(NON_CAMEL_CASE_TYPES, span, &m);
         }

--- a/src/test/ui/lint/lint-group-nonstandard-style.stderr
+++ b/src/test/ui/lint/lint-group-nonstandard-style.stderr
@@ -1,7 +1,7 @@
-warning: type `snake_case` should have a camel case name such as `SnakeCase`
+warning: type `snake_case` should have an upper camel case name such as `SnakeCase`
   --> $DIR/lint-group-nonstandard-style.rs:22:9
    |
-LL |         struct snake_case; //~ WARN should have a camel
+LL |         struct snake_case; //~ WARN should have an upper camel
    |         ^^^^^^^^^^^^^^^^^^
    |
 note: lint level defined here

--- a/src/test/ui/lint/lint-non-camel-case-types.rs
+++ b/src/test/ui/lint/lint-non-camel-case-types.rs
@@ -2,31 +2,31 @@
 #![allow(dead_code)]
 
 struct ONE_TWO_THREE;
-//~^ ERROR type `ONE_TWO_THREE` should have a camel case name such as `OneTwoThree`
+//~^ ERROR type `ONE_TWO_THREE` should have an upper camel case name such as `OneTwoThree`
 
-struct foo { //~ ERROR type `foo` should have a camel case name such as `Foo`
+struct foo { //~ ERROR type `foo` should have an upper camel case name such as `Foo`
     bar: isize,
 }
 
-enum foo2 { //~ ERROR type `foo2` should have a camel case name such as `Foo2`
+enum foo2 { //~ ERROR type `foo2` should have an upper camel case name such as `Foo2`
     Bar
 }
 
-struct foo3 { //~ ERROR type `foo3` should have a camel case name such as `Foo3`
+struct foo3 { //~ ERROR type `foo3` should have an upper camel case name such as `Foo3`
     bar: isize
 }
 
-type foo4 = isize; //~ ERROR type `foo4` should have a camel case name such as `Foo4`
+type foo4 = isize; //~ ERROR type `foo4` should have an upper camel case name such as `Foo4`
 
 enum Foo5 {
-    bar //~ ERROR variant `bar` should have a camel case name such as `Bar`
+    bar //~ ERROR variant `bar` should have an upper camel case name such as `Bar`
 }
 
-trait foo6 { //~ ERROR trait `foo6` should have a camel case name such as `Foo6`
+trait foo6 { //~ ERROR trait `foo6` should have an upper camel case name such as `Foo6`
     fn dummy(&self) { }
 }
 
-fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have a camel case name such as `Ty`
+fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have an upper camel case name such as `Ty`
 
 #[repr(C)]
 struct foo7 {
@@ -35,10 +35,10 @@ struct foo7 {
 
 struct X86_64;
 
-struct X86__64; //~ ERROR type `X86__64` should have a camel case name such as `X86_64`
+struct X86__64; //~ ERROR type `X86__64` should have an upper camel case name such as `X86_64`
 
-struct Abc_123; //~ ERROR type `Abc_123` should have a camel case name such as `Abc123`
+struct Abc_123; //~ ERROR type `Abc_123` should have an upper camel case name such as `Abc123`
 
-struct A1_b2_c3; //~ ERROR type `A1_b2_c3` should have a camel case name such as `A1B2C3`
+struct A1_b2_c3; //~ ERROR type `A1_b2_c3` should have an upper camel case name such as `A1B2C3`
 
 fn main() { }

--- a/src/test/ui/lint/lint-non-camel-case-types.stderr
+++ b/src/test/ui/lint/lint-non-camel-case-types.stderr
@@ -1,4 +1,4 @@
-error: type `ONE_TWO_THREE` should have a camel case name such as `OneTwoThree`
+error: type `ONE_TWO_THREE` should have an upper camel case name such as `OneTwoThree`
   --> $DIR/lint-non-camel-case-types.rs:4:1
    |
 LL | struct ONE_TWO_THREE;
@@ -10,72 +10,72 @@ note: lint level defined here
 LL | #![forbid(non_camel_case_types)]
    |           ^^^^^^^^^^^^^^^^^^^^
 
-error: type `foo` should have a camel case name such as `Foo`
+error: type `foo` should have an upper camel case name such as `Foo`
   --> $DIR/lint-non-camel-case-types.rs:7:1
    |
-LL | / struct foo { //~ ERROR type `foo` should have a camel case name such as `Foo`
+LL | / struct foo { //~ ERROR type `foo` should have an upper camel case name such as `Foo`
 LL | |     bar: isize,
 LL | | }
    | |_^
 
-error: type `foo2` should have a camel case name such as `Foo2`
+error: type `foo2` should have an upper camel case name such as `Foo2`
   --> $DIR/lint-non-camel-case-types.rs:11:1
    |
-LL | / enum foo2 { //~ ERROR type `foo2` should have a camel case name such as `Foo2`
+LL | / enum foo2 { //~ ERROR type `foo2` should have an upper camel case name such as `Foo2`
 LL | |     Bar
 LL | | }
    | |_^
 
-error: type `foo3` should have a camel case name such as `Foo3`
+error: type `foo3` should have an upper camel case name such as `Foo3`
   --> $DIR/lint-non-camel-case-types.rs:15:1
    |
-LL | / struct foo3 { //~ ERROR type `foo3` should have a camel case name such as `Foo3`
+LL | / struct foo3 { //~ ERROR type `foo3` should have an upper camel case name such as `Foo3`
 LL | |     bar: isize
 LL | | }
    | |_^
 
-error: type `foo4` should have a camel case name such as `Foo4`
+error: type `foo4` should have an upper camel case name such as `Foo4`
   --> $DIR/lint-non-camel-case-types.rs:19:1
    |
-LL | type foo4 = isize; //~ ERROR type `foo4` should have a camel case name such as `Foo4`
+LL | type foo4 = isize; //~ ERROR type `foo4` should have an upper camel case name such as `Foo4`
    | ^^^^^^^^^^^^^^^^^^
 
-error: variant `bar` should have a camel case name such as `Bar`
+error: variant `bar` should have an upper camel case name such as `Bar`
   --> $DIR/lint-non-camel-case-types.rs:22:5
    |
-LL |     bar //~ ERROR variant `bar` should have a camel case name such as `Bar`
+LL |     bar //~ ERROR variant `bar` should have an upper camel case name such as `Bar`
    |     ^^^
 
-error: trait `foo6` should have a camel case name such as `Foo6`
+error: trait `foo6` should have an upper camel case name such as `Foo6`
   --> $DIR/lint-non-camel-case-types.rs:25:1
    |
-LL | / trait foo6 { //~ ERROR trait `foo6` should have a camel case name such as `Foo6`
+LL | / trait foo6 { //~ ERROR trait `foo6` should have an upper camel case name such as `Foo6`
 LL | |     fn dummy(&self) { }
 LL | | }
    | |_^
 
-error: type parameter `ty` should have a camel case name such as `Ty`
+error: type parameter `ty` should have an upper camel case name such as `Ty`
   --> $DIR/lint-non-camel-case-types.rs:29:6
    |
-LL | fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have a camel case name such as `Ty`
+LL | fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have an upper camel case name such as `Ty`
    |      ^^
 
-error: type `X86__64` should have a camel case name such as `X86_64`
+error: type `X86__64` should have an upper camel case name such as `X86_64`
   --> $DIR/lint-non-camel-case-types.rs:38:1
    |
-LL | struct X86__64; //~ ERROR type `X86__64` should have a camel case name such as `X86_64`
+LL | struct X86__64; //~ ERROR type `X86__64` should have an upper camel case name such as `X86_64`
    | ^^^^^^^^^^^^^^^
 
-error: type `Abc_123` should have a camel case name such as `Abc123`
+error: type `Abc_123` should have an upper camel case name such as `Abc123`
   --> $DIR/lint-non-camel-case-types.rs:40:1
    |
-LL | struct Abc_123; //~ ERROR type `Abc_123` should have a camel case name such as `Abc123`
+LL | struct Abc_123; //~ ERROR type `Abc_123` should have an upper camel case name such as `Abc123`
    | ^^^^^^^^^^^^^^^
 
-error: type `A1_b2_c3` should have a camel case name such as `A1B2C3`
+error: type `A1_b2_c3` should have an upper camel case name such as `A1B2C3`
   --> $DIR/lint-non-camel-case-types.rs:42:1
    |
-LL | struct A1_b2_c3; //~ ERROR type `A1_b2_c3` should have a camel case name such as `A1B2C3`
+LL | struct A1_b2_c3; //~ ERROR type `A1_b2_c3` should have an upper camel case name such as `A1B2C3`
    | ^^^^^^^^^^^^^^^^
 
 error: aborting due to 11 previous errors


### PR DESCRIPTION
Rust structs should be named in upper camel case aka PascalCase. “Upper camel case” was decided upon as the preferred phrase over PascalCase per: https://github.com/rust-lang/rfcs/pull/2389

Updated 5 files in linter